### PR TITLE
Update auth.py to return Str rather than Byte

### DIFF
--- a/MTPythonSampleCode/auth.py
+++ b/MTPythonSampleCode/auth.py
@@ -49,4 +49,4 @@ class AzureAuthClient(object):
             self.token = response.content
             self.reuse_token_until = datetime.utcnow() + timedelta(minutes=5)
 
-        return self.token
+        return self.token.decode("utf-8")


### PR DESCRIPTION
the generated token was being returned as a Byte type rather than Str which meant that the subsequent calls using the token failed